### PR TITLE
fix: Remove long institute name from header

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -290,7 +290,6 @@ const Index = () => {
               </div>
               <div>
                 <h1 className="text-xl font-bold text-gray-900">MIT Campus</h1>
-                <p className="text-xs text-gray-600">Muzaffarpur Institute of Technology</p>
               </div>
             </div>
             


### PR DESCRIPTION
Removed 'Muzaffarpur Institute of Technology' text from the header in the Index page to prevent layout overflow.